### PR TITLE
Created more helper commands in WarDev.

### DIFF
--- a/MMOCoreORB/src/server/zone/objects/creature/commands/WarDevCommand.h
+++ b/MMOCoreORB/src/server/zone/objects/creature/commands/WarDevCommand.h
@@ -10,16 +10,16 @@
 
 #include "server/zone/objects/scene/SceneObject.h"
 #include "server/zone/managers/director/DirectorManager.h"
+// #include "server/ServerCore.h"
 
 class WarDevCommand : public QueueCommand {
 public:
 
-	WarDevCommand(const String& name, ZoneProcessServer* server)
-		: QueueCommand(name, server) {
-
+	WarDevCommand(const String& name, ZoneProcessServer* server): QueueCommand(name, server) {
 	}
 
 	int doQueueCommand(CreatureObject* creature, const uint64& target, const UnicodeString& arguments) const {
+		creature->sendSystemMessage("Attempted to use WarDev command!");
 
 		if (!checkStateMask(creature))
 			return INVALIDSTATE;
@@ -63,8 +63,9 @@ public:
 						args.getStringToken(adminCommand);
 						adminCommand = adminCommand.toLowerCase();
 
-						if (target == 0 && (adminCommand == "spoutmobile" || adminCommand == "spoutobject" || adminCommand == "spoutstatic")){
-							creature->sendSystemMessage("Target required for /wardev admin spoutMobile, spoutObject, spoutStatic");
+						// Added new target-based commands
+						if (target == 0 && (adminCommand == "spoutmobile" || adminCommand == "spoutobject" || adminCommand == "spoutstatic" || adminCommand == "spoutcreoquat" || adminCommand == "spoutcreoquatvis" || adminCommand == "deletetargobj")){
+							creature->sendSystemMessage("Target required for this WarDev command!");
 							return GENERALERROR;
 						}
 
@@ -97,6 +98,35 @@ public:
 							spout(creature, &args, formatSpoutText(creature, target, 3));
 						} else if(adminCommand == "spoutonme") {
 							spout(creature, &args, formatSpoutText(creature, target, 4));
+						} else if(adminCommand == "spoutonmevis") {
+							spout(creature, &args, formatSpoutText(creature, target, 5));
+						} else if(adminCommand == "spoutcreoquat") {
+							// Paranoid anti-segfault check, should not need this.
+							if (target != 0) {
+								if(!object->isCreatureObject()){
+									creature->sendSystemMessage("Target is NOT a Creature! HELP!");
+									return GENERALERROR;
+								}
+								spout(creature, &args, formatSpoutText(creature, target, 6));
+							}
+						} else if(adminCommand == "spoutcreoquatvis") {
+							// Paranoid anti-segfault check, should not need this.
+							if (target != 0) {
+								if(!object->isCreatureObject()){
+									creature->sendSystemMessage("Target is NOT a Creature! HELP!");
+									return GENERALERROR;
+								}
+								spout(creature, &args, formatSpoutText(creature, target, 7));
+							}
+						} else if(adminCommand == "deletetargobj") {
+							// Paranoid anti-segfault check, should not need this.
+							if (target != 0) {
+								if(object->isCreatureObject()){
+									creature->sendSystemMessage("Target is NOT an Object! HELP!");
+									return GENERALERROR;
+								}
+							}
+							spout(creature, &args, formatSpoutText(creature, target, 8), adminCommand);
 						} else if(adminCommand == "spoutroom") {
 							spout(creature, &args, formatSpoutTextMulti(creature, 1));
 						} else if(adminCommand == "spoutbuilding") {
@@ -135,7 +165,23 @@ public:
 						text << "/wardev admin spoutMobile [file_name]" << endl;
 						text << "- spawnMobile for the targeted creature."  << endl;
 						text << "/wardev admin spoutOnme [file_name]"  << endl;
-						text << "- spawnMobile based on where you are standing and facing. Default mobile type: commoner."  << endl;
+						text << "- Old command that only returns xyz 'spawnMobile' based on where you are standing and facing."  << endl;
+						// ------------------------------------------
+						// NEW CUSTOM WF -- Boogles
+						// spoutonmevis
+						text << "/wardev admin spoutOnMeVis [file_name]"  << endl;
+						text << "- New command that will spawn a visual helper NPC based on where you are standing and facing. Default mobile type: commoner."  << endl;
+						// spoutcreoquat
+						text << "/wardev admin spoutCreoQuat [file_name]"  << endl;
+						text << "- New command that will return the Quaternian positional values needed for objects based on xyz and facing of a targed CreatureObject."  << endl;
+						// spoutcreoquatvis
+						text << "/wardev admin spoutCreoQuatVis [file_name]"  << endl;
+						text << "- New command that will return the Quaternian positional values needed for objects, and spawns a helper Object, based on xyz and facing of a targed CreatureObject."  << endl;
+						// deletetargobj
+						text << "/wardev admin deleteTargObject [file_name]"  << endl;
+						text << "- New command that will delete a targetable object from the world."  << endl;
+						// NEW CUSTOM WF -- Boogles
+						// ------------------------------------------
 						text << "/wardev admin spoutObject [file_name]"  << endl;
 						text << "- spawnSceneObject for the targeted object."  << endl;
 						text << "/wardev admin spoutStatic [file_name]"  << endl;
@@ -275,6 +321,94 @@ public:
 				text << worldPosition.getX() << ", " << worldPosition.getZ() << ", " << worldPosition.getY() << ", " << angle << ", " << "0" << ")";
 			}
 			// Returning: spawnMobile("planet", "commoner", 1, x, z, y, heading, cellid)
+		} else if (textType == 5) {
+			int angle = creature->getDirectionAngle();
+
+			text << "spawnMobile(\"" << planetName << "\", " <<  "\"commoner" << "\", 1, ";
+
+			// Spawn NPC visualization part
+			if (creature->getParent() != nullptr && creature->getParent().get()->isCellObject()) {
+				// Inside
+				ManagedReference<CellObject*> cell = cast<CellObject*>( creature->getParent().get().get());
+				Vector3 cellPosition = creature->getPosition();
+
+				text << cellPosition.getX() << ", " << cellPosition.getZ() << ", " << cellPosition.getY() << ", " << angle << ", " << cell->getObjectID() << ")";
+
+				// Spawn Visual Helper
+				spawnVisualNPCHelper(creature, cellPosition.getX(), cellPosition.getY(), cellPosition.getZ(), cell->getObjectID());
+			}else {
+				// Outside
+				Vector3 worldPosition = creature->getWorldPosition();
+
+				text << worldPosition.getX() << ", " << worldPosition.getZ() << ", " << worldPosition.getY() << ", " << angle << ", " << "0" << ")";
+
+				// Spawn Visual Helper
+				spawnVisualNPCHelper(creature, worldPosition.getX(), worldPosition.getY(), worldPosition.getZ(), 0);
+			}
+		} else if (textType == 6) {
+			text << "spawnSceneObject(\"" << planetName << "\", \"" << templateFile << "\", ";
+
+			if (creature->getParent() != nullptr && creature->getParent().get()->isCellObject()) {
+				// Inside
+				ManagedReference<CellObject*> cell = cast<CellObject*>( creature->getParent().get().get());
+				Vector3 cellPosition = creature->getPosition();
+
+				text << cellPosition.getX() << ", " << cellPosition.getZ() << ", " << cellPosition.getY() << ", " << cell->getObjectID() << ", ";
+			}else {
+				// Outside
+				Vector3 worldPosition = creature->getWorldPosition();
+				text << worldPosition.getX() << ", " << worldPosition.getZ() << ", " << worldPosition.getY() << ", " << "0" << ", ";
+			}
+
+			const Quaternion* dir = creature->getDirection();
+			text << dir->getW() << ", " << dir->getX() << ", " << dir->getY() << ", " << dir->getZ() << ")";
+			// Returning: spawnSceneObject("planet", "objectTemplateFilePathAndName", x, z, y, cellNumber, dw, dx, dy, dz>
+		} else if (textType == 7) {
+			text << "spawnSceneObject(\"" << planetName << "\", \"" << templateFile << "\", ";
+			
+			// Convert Target to a CREO
+			ManagedReference<SceneObject*> targetObject = server->getZoneServer()->getObject(target, false);
+
+			// Grab Quat earlier so we can spawn something from it based on inside/outside!
+			const Quaternion* dir = nullptr;
+			if (targetObject != nullptr) {
+				dir = targetObject->getDirection();
+			}
+
+			if (targetObject->getParent() != nullptr && targetObject->getParent().get()->isCellObject()) {
+				// Inside
+				ManagedReference<CellObject*> cell = cast<CellObject*>( targetObject->getParent().get().get());
+				Vector3 cellPosition = targetObject->getPosition();
+				text << cellPosition.getX() << ", " << cellPosition.getZ() << ", " << cellPosition.getY() << ", " << cell->getObjectID() << ", ";
+
+				// Spawn Visual Helper for SceneObjects
+				spawnVisualObjectHelper(creature, cellPosition.getX(), cellPosition.getY(), cellPosition.getZ(), cell->getObjectID(), dir->getW(), dir->getX(), dir->getY(), dir->getZ());
+			}else {
+				// Outside
+				Vector3 worldPosition = targetObject->getWorldPosition();
+				text << worldPosition.getX() << ", " << worldPosition.getZ() << ", " << worldPosition.getY() << ", " << "0" << ", ";
+
+				// Spawn Visual Helper for SceneObjects
+				spawnVisualObjectHelper(creature, worldPosition.getX(), worldPosition.getY(), worldPosition.getZ(), 0, dir->getW(), dir->getX(), dir->getY(), dir->getZ());
+			}
+
+			// const Quaternion* dir = creature->getDirection();
+			text << dir->getW() << ", " << dir->getX() << ", " << dir->getY() << ", " << dir->getZ() << ")";
+			// Returning: spawnSceneObject("planet", "objectTemplateFilePathAndName", x, z, y, cellNumber, dw, dx, dy, dz>
+		} else if (textType == 8) { 
+			// Delete Targeted Object
+
+			// This is how to get an object by its ID when targeted...
+			ManagedReference<SceneObject*> objectToDelete = server->getZoneServer()->getObject(target, false);
+			
+			if (objectToDelete != nullptr) {
+				// Test Destroy
+				objectToDelete->destroyChildObjects();
+				objectToDelete->destroyObjectFromWorld(true);
+				objectToDelete->destroyObjectFromDatabase(true);
+			} else {
+				creature->sendSystemMessage("TargetObject was NULL!");
+			}
 		}
 
 		return text.toString();
@@ -348,27 +482,35 @@ public:
 
 
 	// Ouput screenplay formated code to a file on the server
-	void spout(CreatureObject* creature, StringTokenizer* args, String outputText) const {
-		if(creature->getZoneServer() == nullptr)
-			return;
+	// Boogles-Note: I overloaded the spout command with the given command so we can pivot special cases.
+	void spout(CreatureObject* creature, StringTokenizer* args, String outputText, String command = "unknown") const {
+		// Custom Pivot, could have done this differently but it works out just fine.
+		if (command != "deletetargobj") {
+			if(creature->getZoneServer() == nullptr)
+				return;
 
-		String fileName = "";
-		if(args->hasMoreTokens())
-			args->getStringToken(fileName);
+			String fileName = "";
+			if(args->hasMoreTokens()) {
+				args->getStringToken(fileName);
+			}
 
-		if(fileName.isEmpty())
-			throw Exception();
 
-		File* file = new File("custom_scripts/spout/" + fileName + ".lua");
-		FileWriter* writer = new FileWriter(file, true); // true for appending new lines
+			if(fileName.isEmpty()) {
+				throw Exception();
+			}
 
-		writer->writeLine(outputText);
+		
+			File* file = new File("custom_scripts/spout/" + fileName + ".lua");
+			FileWriter* writer = new FileWriter(file, true); // true for appending new lines
 
-		writer->close();
-		delete file;
-		delete writer;
+			writer->writeLine(outputText);
 
-		creature->sendSystemMessage("Data written to bin/custom_scripts/spout/" + fileName + ".lua!");
+			writer->close();
+			delete file;
+			delete writer;
+
+			creature->sendSystemMessage("Data written to bin/custom_scripts/spout/" + fileName + ".lua!");
+		}
 	}
 
 	void decor(CreatureObject* creature) const {
@@ -392,6 +534,100 @@ public:
 		*adminPlaceStructure << creature;
 
 		adminPlaceStructure->callFunction();
+	}
+
+	// Method for spawning a 'Commoner' NPC as a "Visual Helper" for building, or enhancing, POIs
+	void spawnVisualNPCHelper(CreatureObject* creature, float x, float y, float z, uint64 parID) const {
+		// ========================================================
+		// Spawn helper NPC to help visualize placement
+
+		// Create Creature
+		Zone* zone = creature->getZone();
+		CreatureManager* creatureManager = zone->getCreatureManager();
+		AiAgent* npc = nullptr;
+		String templateName = "commoner";
+		uint32 objTempl = 0;
+		uint32 templ = templateName.hashCode();
+
+		// Setup npc definition
+		npc = cast<AiAgent*>(creatureManager->spawnCreature(templ, objTempl, x, z, y, parID));
+
+		Locker clocker(npc, creature);
+
+		float scale = -1.0;
+		npc->updateDirection(Math::deg2rad(creature->getDirectionAngle()));
+		
+		if (scale > 0 && scale != 1.0){
+			npc->setHeight(scale);
+		}
+
+		// Done spawning visual example
+		// ========================================================
+	}
+
+	// dir->getW(), dir->getX(), dir->getY(), dir->getZ()
+	// Method for spawning a 'Commoner' NPC as a "Visual Helper" for building, or enhancing, POIs
+	void spawnVisualObjectHelper(CreatureObject* creature, float x, float y, float z, uint64 parID, float dw, float dx, float dy, float dz) const {
+		// ========================================================
+		// Spawn helper Object to help visualize placement
+
+		// Create Creature
+		Zone* zone = creature->getZone();
+		if (zone == nullptr) {
+			creature->sendSystemMessage("Could not get current zone! Where are you??");
+			return;
+		}
+
+		// Convert path to template to templateCRC hash
+		uint32 templ = String::hashCode("object/tangible/terminal/terminal_hq_imperial.iff");
+
+		// Setup ZoneServer so we can transfer the newly created object to the world.
+		ZoneServer* zoneServer = ServerCore::getZoneServer();
+
+		// Init the new object.
+		ManagedReference<SceneObject*> object = zoneServer->createObject(templ, 0);
+		if (object != nullptr) {
+			// Lock our new Object
+			Locker objLocker(object);
+
+			// Init Pos
+			object->initializePosition(x, z, y);
+			object->setDirection(dw, dx, dy, dz);
+
+			// Init CellParent
+			Reference<SceneObject*> cellParent = nullptr;
+
+			// Making sure our parent exists!
+			if (parID != 0) {
+				cellParent = zoneServer->getObject(parID);
+
+				// If our parent is NOT a CellObject then make sure it is actually null!
+				if (cellParent != nullptr && !cellParent->isCellObject()) {
+					cellParent = nullptr;
+				}
+			}
+
+			// If our Parent IS a CellParent (inside a building, for example) then transfer correctly and replicate to clients.
+			if (cellParent != nullptr) {
+				cellParent->broadcastObject(object, true);
+				cellParent->transferObject(object, -1, true);
+			} else {
+				// Probably open world? Transfer accordingly!
+				zone->transferObject(object, -1, true);
+			}
+
+			// Does our new object have children? If so, populate those too!
+			object->createChildObjects();
+
+			// Mark as updated so the Garbage Collector doesn't delete our new object from the world.
+			object->_setUpdated(true);
+		}
+		else {
+			String err = "Could not spawn object helper template!";
+		}
+
+		// Done spawning visual example
+		// ========================================================
 	}
 
 };


### PR DESCRIPTION
Pulled Carbonite's WarDev and updated it for WF with more commands:
- Added "spoutonmevis" command that will create a "Visual Helper" NPC at your given location + rotation
- Added "spoutcreoquat" command that will return the Quaternian coordinates of a targeted CreoObject
- Added "spoutcreoquatvis" command that does he same as the above, but also creates a helper world object for visibility
- Added "deletetargobj" command that will allow you to cleanup any world object (helpful for cleaning up the former obj helpers)